### PR TITLE
Fixed toArrayBuffer in the browser

### DIFF
--- a/src/bee-client.js
+++ b/src/bee-client.js
@@ -4,6 +4,9 @@ const join = require('./asyncJoiner')
 const dfeeds = require('dfeeds')
 
 function toArrayBuffer(buf) {
+    if (buf instanceof ArrayBuffer) {
+        return buf;
+    }
     var ab = new ArrayBuffer(buf.length);
     var view = new Uint8Array(ab);
     for (var i = 0; i < buf.length; ++i) {


### PR DESCRIPTION
I had an issue with the ArrayBuffer conversion in the browser (e.g. Chrome). Turns out that axios already returned an ArrayBuffer and the conversion we did there did not work. So I added a check if the passed in object is an ArrayBuffer and if it is return it.